### PR TITLE
Use stricter autoconf syntax imposed by newer versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,10 +101,10 @@ else
 have_function=yes, have_function=no)
    if test "x$have_function" = "xyes"; then
       AC_MSG_RESULT(yes)
-      AC_DEFINE(__func__, __FUNCTION__)
+      AC_DEFINE(__func__, __FUNCTION__, [__FUNCTION__ is available])
    else
       AC_MSG_RESULT(no)
-      AC_DEFINE(__func__, __FILE__)
+      AC_DEFINE(__func__, __FILE__, [Use __FILE__ since __FUNCTION__ is not available])
    fi
 fi
 
@@ -130,7 +130,7 @@ AC_CACHE_CHECK(if sockaddr{} has sa_len member, ac_cv_sockaddr_has_sa_len,
         ac_cv_sockaddr_has_sa_len=yes,
         ac_cv_sockaddr_has_sa_len=no))
 if test $ac_cv_sockaddr_has_sa_len = yes ; then
-        AC_DEFINE(HAVE_SOCKADDR_SA_LEN)
+        AC_DEFINE([HAVE_SOCKADDR_SA_LEN], [1], [struct sockaddr has sa_len member])
 fi
 
 #dnl check endedness
@@ -139,11 +139,11 @@ AC_C_BIGENDIAN
 AC_MSG_CHECKING([if struct in_addr is a wacky huge structure (some Sun boxes)])
 
 AC_TRY_COMPILE([#include <netinet/in.h>], struct in_addr i; i._S_un._S_addr;, \
-             AC_DEFINE(IN_ADDR_DEEPSTRUCT) \
+             AC_DEFINE([IN_ADDR_DEEPSTRUCT], [1], [struct in_addr is a whacky huge structure]]) \
              AC_MSG_RESULT(yes) , \
              AC_TRY_COMPILE([#include <sys/types.h>
 #include <netinet/in.h>], struct in_addr i; i.S_un.S_addr;, \
-                             AC_DEFINE(IN_ADDR_DEEPSTRUCT) \
+                             AC_DEFINE([IN_ADDR_DEEPSTRUCT], [1], [struct in_addr is a whacky huge structure]) \
                              AC_MSG_RESULT(yes) , \
                              AC_MSG_RESULT(no);))
 
@@ -241,7 +241,7 @@ fi
 OPENSSL_LIBS=
 if test "$use_openssl" = "yes"; then
 
-  AC_DEFINE(HAVE_OPENSSL)
+  AC_DEFINE([HAVE_OPENSSL], [1], [OpenSSL is available])
   OPENSSL_LIBS="-lssl -lcrypto"
 fi
 

--- a/nbase/acinclude.m4
+++ b/nbase/acinclude.m4
@@ -11,7 +11,7 @@ dnl Note that if the system doesn't have gai_strerror(), we
 dnl can't use getaddrinfo() because we can't get strings
 dnl describing the error codes.
 dnl
-AC_DEFUN(APR_CHECK_WORKING_GETADDRINFO,[
+AC_DEFUN([APR_CHECK_WORKING_GETADDRINFO],[
   AC_CACHE_CHECK(for working getaddrinfo, ac_cv_working_getaddrinfo,[
   AC_TRY_RUN( [
 #ifdef HAVE_NETDB_H
@@ -54,7 +54,7 @@ if test "$ac_cv_working_getaddrinfo" = "yes"; then
   if test "$ac_cv_func_gai_strerror" != "yes"; then
     ac_cv_working_getaddrinfo="no"
   else
-    AC_DEFINE(HAVE_GETADDRINFO, 1, [Define if getaddrinfo exists and works well enough for APR])
+    AC_DEFINE([HAVE_GETADDRINFO], [1], [Define if getaddrinfo exists and works well enough for APR])
   fi
 fi
 ])
@@ -62,7 +62,7 @@ fi
 dnl
 dnl check for working getnameinfo() -- from Apache 2.0.40
 dnl
-AC_DEFUN(APR_CHECK_WORKING_GETNAMEINFO,[
+AC_DEFUN([APR_CHECK_WORKING_GETNAMEINFO],[
   AC_CACHE_CHECK(for working getnameinfo, ac_cv_working_getnameinfo,[
   AC_TRY_RUN( [
 #ifdef HAVE_NETDB_H
@@ -113,11 +113,11 @@ int main(void) {
   ac_cv_working_getnameinfo="yes"
 ])])
 if test "$ac_cv_working_getnameinfo" = "yes"; then
-  AC_DEFINE(HAVE_GETNAMEINFO, 1, [Define if getnameinfo exists])
+  AC_DEFINE([HAVE_GETNAMEINFO], [1], [Define if getnameinfo exists])
 fi
 ])
 
-AC_DEFUN(APR_CHECK_SOCKADDR_IN6,[
+AC_DEFUN([APR_CHECK_SOCKADDR_IN6],[
 AC_CACHE_CHECK(for sockaddr_in6, ac_cv_define_sockaddr_in6,[
 AC_TRY_COMPILE([
 #ifdef HAVE_SYS_TYPES_H
@@ -137,13 +137,13 @@ struct sockaddr_in6 sa;
 
 if test "$ac_cv_define_sockaddr_in6" = "yes"; then
   have_sockaddr_in6=1
-  AC_DEFINE(HAVE_SOCKADDR_IN6)
+  AC_DEFINE([HAVE_SOCKADDR_IN6], [1], [struct sockaddr_in6 is available])
 else
   have_sockaddr_in6=0
 fi
 ])
 
-AC_DEFUN(CHECK_AF_INET6_DEFINE,[
+AC_DEFUN([CHECK_AF_INET6_DEFINE],[
 AC_CACHE_CHECK(for AF_INET6 definition, ac_cv_define_af_inet6,[
 AC_TRY_COMPILE([
 #ifdef HAVE_SYS_TYPES_H
@@ -166,13 +166,13 @@ int af = AF_INET6;
 
 if test "$ac_cv_define_af_inet6" = "yes"; then
   have_af_inet6=1
-  AC_DEFINE(HAVE_AF_INET6)
+  AC_DEFINE([HAVE_AF_INET6], [1], [AF_INET6 macro is defined])
 else
   have_af_inet6=0
 fi
 ])
 
-AC_DEFUN(APR_CHECK_SOCKADDR_STORAGE,[
+AC_DEFUN([APR_CHECK_SOCKADDR_STORAGE],[
 AC_CACHE_CHECK(for sockaddr_storage, ac_cv_define_sockaddr_storage,[
 AC_TRY_COMPILE([
 #ifdef HAVE_SYS_TYPES_H
@@ -195,21 +195,21 @@ struct sockaddr_storage sa;
 
 if test "$ac_cv_define_sockaddr_storage" = "yes"; then
   have_sockaddr_storage=1
-  AC_DEFINE(HAVE_SOCKADDR_STORAGE)
+  AC_DEFINE([HAVE_SOCKADDR_STORAGE], [1], [struct sockaddr_storage is available])
 else
   have_sockaddr_storage=0
 fi
 ])
 
 dnl This test taken from GCC libjava.
-AC_DEFUN(CHECK_PROC_SELF_EXE,[
+AC_DEFUN([CHECK_PROC_SELF_EXE],[
   if test x"$cross_compiling" = x"no"; then
     AC_CHECK_FILES(/proc/self/exe, [
-      AC_DEFINE(HAVE_PROC_SELF_EXE, 1, [Define if you have /proc/self/exe])])
+      AC_DEFINE([HAVE_PROC_SELF_EXE], [1], [Define if you have /proc/self/exe])])
   else
     case $host in
       *-linux*)
-      AC_DEFINE(HAVE_PROC_SELF_EXE, 1, [Define if you have /proc/self/exe])
+      AC_DEFINE([HAVE_PROC_SELF_EXE], [1], [Define if you have /proc/self/exe])
       ;;
     esac
   fi

--- a/nbase/configure.ac
+++ b/nbase/configure.ac
@@ -60,7 +60,7 @@ AC_C_INLINE
 case "$host" in
   *-sgi-irix5* | *-sgi-irix6*)
     if test -z "$GCC"; then
-      AC_DEFINE(inline, )
+      AC_DEFINE([inline], [], [Disable inline keyword])
     fi
     ;;
 esac
@@ -129,7 +129,7 @@ AC_CACHE_CHECK(if sockaddr{} has sa_len member, ac_cv_sockaddr_has_sa_len,
         ac_cv_sockaddr_has_sa_len=yes,
         ac_cv_sockaddr_has_sa_len=no))
 if test $ac_cv_sockaddr_has_sa_len = yes ; then
-        AC_DEFINE(HAVE_SOCKADDR_SA_LEN)
+        AC_DEFINE([HAVE_SOCKADDR_SA_LEN], [1], [struct sockaddr has sa_len member])
 fi
 
 dnl check endedness
@@ -225,7 +225,7 @@ AC_LIBOBJ([getnameinfo])
 fi
 
 if test "$have_ipv6" = "1"; then
-  AC_DEFINE(HAVE_IPV6)
+  AC_DEFINE([HAVE_IPV6], [1], [Everything needed for IPv6 support is available])
 fi
 
 # First we test whether they specified openssl desires explicitly
@@ -286,7 +286,7 @@ talled you can try the --with-openssl=DIR argument]) ])
 fi
 
 if test "$use_openssl" = "yes"; then
-  AC_DEFINE(HAVE_OPENSSL)
+  AC_DEFINE([HAVE_OPENSSL], [1], [OpenSSL is available])
 fi
 
 CHECK_PROC_SELF_EXE

--- a/nsock/src/configure.ac
+++ b/nsock/src/configure.ac
@@ -26,66 +26,66 @@ AC_CANONICAL_HOST
 
 case "$host" in
   *alpha-dec-osf*)
-    AC_DEFINE(DEC)
+    AC_DEFINE([DEC], [1], [host is alpha-dec-osf*])
     ;;
   *-netbsd* | *-knetbsd*-gnu)
-    AC_DEFINE(NETBSD)
+    AC_DEFINE([NETBSD], [1], [host is NetBSD])
     ;;
   *-openbsd*)
-    AC_DEFINE(OPENBSD)
+    AC_DEFINE([OPENBSD], [1], [host is OpenBSD])
     ;;
   *-sgi-irix5*)
-    AC_DEFINE(IRIX)
+    AC_DEFINE([IRIX], [1], [host is Irix])
     ;;
   *-sgi-irix6*)
-    AC_DEFINE(IRIX)
+    AC_DEFINE([IRIX], [1], [host is Irix])
     ;;
   *-hpux*)
-    AC_DEFINE(HPUX)
+    AC_DEFINE([HPUX], [1], [Host is HP Unix])
     ;;
   *-solaris2.1[[1-9]]*)
-    AC_DEFINE(SOLARIS)
+    AC_DEFINE([SOLARIS], [1], [Host is Solaris])
     # Solaris 11 and later use BPF packet capture rather than DLPI.
-    AC_DEFINE(SOLARIS_BPF_PCAP_CAPTURE)
+    AC_DEFINE([SOLARIS_BPF_PCAP_CAPTURE], [], [Use BPF packet capture in Solaris >= 11])
     ;;
   *-solaris2.0*)  
-    AC_DEFINE(SOLARIS)
+    AC_DEFINE([SOLARIS], [1], [Host is Solaris])
     ;;
   *-solaris2.[[1-9]][[0-9]]*)
-    AC_DEFINE(SOLARIS)
+    AC_DEFINE([SOLARIS], [1], [Host is Solaris])
     ;;
   *-solaris2.1*)
-    AC_DEFINE(SOLARIS)
+    AC_DEFINE([SOLARIS], [1], [Host is Solaris])
     ;;
   *-solaris2.2*)
-    AC_DEFINE(SOLARIS)
+    AC_DEFINE([SOLARIS], [1], [Host is Solaris])
     ;;
   *-solaris2.3*)
-    AC_DEFINE(SOLARIS)
+    AC_DEFINE([SOLARIS], [1], [Host is Solaris])
     ;;
   *-solaris2.4*)
-    AC_DEFINE(SOLARIS)
+    AC_DEFINE([SOLARIS], [1], [Host is Solaris])
     ;;
   *-solaris2.5.1)
-    AC_DEFINE(SOLARIS)
+    AC_DEFINE([SOLARIS], [1], [Host is Solaris])
     ;;
   *-solaris*)
-    AC_DEFINE(SOLARIS)
+    AC_DEFINE([SOLARIS], [1], [Host is Solaris])
     ;;
   *-sunos4*)
-    AC_DEFINE(SUNOS)
+    AC_DEFINE([SUNOS], [1], [Host is SunOS])
     ;;
   *-linux*)
-    AC_DEFINE(LINUX)
+    AC_DEFINE([LINUX], [1], [Host is Linux])
     ;;
   *-freebsd* | *-kfreebsd*-gnu | *-dragonfly*)
-    AC_DEFINE(FREEBSD)
+    AC_DEFINE([FREEBSD], [1], [Host is FreeBSD])
     ;;
   *-bsdi*)
-    AC_DEFINE(BSDI)
+    AC_DEFINE([BSDI], [1], [Host is BSDi])
     ;;
   *-apple-darwin*)
-    AC_DEFINE(MACOSX)
+    AC_DEFINE([MACOSX], [1], [Host is MacOS X])
     ;;
 esac
 
@@ -160,7 +160,7 @@ if test "$with_libpcap" != "no" -a "$have_libpcap" = "no"; then
   have_libpcap=yes
 fi
 if test "$have_libpcap" != "no"; then
-  AC_DEFINE(HAVE_PCAP)
+  AC_DEFINE([HAVE_PCAP], [1], [libpcap is available])
   if test "${LIBPCAP_INC+set}" = "set"; then
     CPPFLAGS="-I$LIBPCAP_INC $CPPFLAGS"
     LDFLAGS="-L$LIBPCAP_LIB $LDFLAGS"
@@ -170,9 +170,9 @@ AC_SUBST(LIBPCAP_LIBS)
 
 PCAP_DEFINE_NETMASK_UNKNOWN
 
-AX_HAVE_EPOLL([AC_DEFINE(HAVE_EPOLL)], )
-AX_HAVE_POLL([AC_DEFINE(HAVE_POLL)], )
-AC_CHECK_FUNCS(kqueue kevent, [AC_DEFINE(HAVE_KQUEUE)], )
+AX_HAVE_EPOLL([AC_DEFINE([HAVE_EPOLL], [1], [epoll is available])], )
+AX_HAVE_POLL([AC_DEFINE([HAVE_POLL], [1], [poll is available])], )
+AC_CHECK_FUNCS(kqueue kevent, [AC_DEFINE([HAVE_KQUEUE], [1], [kqueue is available])], )
 
 dnl Checks for programs.
 AC_PROG_CC
@@ -255,7 +255,7 @@ AC_SEARCH_LIBS(dlopen, dl)
 
 OPENSSL_LIBS=
 if test "$use_openssl" = "yes"; then
-  AC_DEFINE(HAVE_OPENSSL)
+  AC_DEFINE([HAVE_OPENSSL], [1], [OpenSSL is available])
   OPENSSL_LIBS="-lssl -lcrypto"
   LIBS="$LIBS $OPENSSL_LIBS"
 fi
@@ -264,7 +264,7 @@ AC_SUBST(OPENSSL_LIBS)
 
 AC_MSG_CHECKING([for SSL_set_tlsext_host_name])
 AC_TRY_LINK([#include <openssl/ssl.h>], [SSL_set_tlsext_host_name(NULL, NULL)],
-  [AC_MSG_RESULT([yes]); AC_DEFINE(HAVE_SSL_SET_TLSEXT_HOST_NAME)],
+  [AC_MSG_RESULT([yes]); AC_DEFINE([HAVE_SSL_SET_TLSEXT_HOST_NAME], [1], [SSL_set_tlsext_host_name is available])],
   [AC_MSG_RESULT([no])])
 
 dnl Checks for typedefs, structures, and compiler characteristics.


### PR DESCRIPTION
This allows the Debian packaging to use "autoreconf" with a recent
version of autoconf.