### PR TITLE
Fix build failure with gcc 7

### DIFF
--- a/ncrack_resume.cc
+++ b/ncrack_resume.cc
@@ -520,7 +520,7 @@ ncrack_resume(char *fname, int *myargc, char ***myargv)
 
       j = 0;
       buf[j++] = *q;
-      while (q != '\0' && j < sizeof(buf)) {
+      while (*q != '\0' && j < sizeof(buf)) {
         q++;
         if (q - filestr >= filelen)
           fatal("Corrupted file! Error 5\n");


### PR DESCRIPTION
This looks like a fairly simple mistake. gcc 7 refuses the comparison of
a pointer with a char. I believe the intent was to dereference the
pointer and compare the character read at the pointer address.

Fixes #24.

Bug-Debian: https://bugs.debian.org/853570