### PR TITLE
Fix memory leak and add SMB2 module

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -47,12 +47,12 @@ export SRCS = ncrack.cc utils.cc TargetGroup.cc Target.cc targets.cc \
 NcrackOps.cc Service.cc ServiceGroup.cc Connection.h services.cc \
 timing.cc ncrack_error.cc output.cc ncrack_tty.cc Buf.cc \
 NcrackOutputTable.cc ncrack_input.cc ncrack_resume.cc crypto.cc http.cc \
-http_digest.cc xml.cc
+http_digest.cc xml.cc ntlmssp.cc
 
 OBJS = ncrack.o utils.o TargetGroup.o Target.o targets.o NcrackOps.o \
 Service.o ServiceGroup.o Connection.o services.o timing.o \
 ncrack_error.o output.o ncrack_tty.o Buf.o NcrackOutputTable.o \
-ncrack_input.o ncrack_resume.o crypto.o http.o http_digest.o xml.o
+ncrack_input.o ncrack_resume.o crypto.o http.o http_digest.o xml.o ntlmssp.o
 
 
 .cc.o :

--- a/configure
+++ b/configure
@@ -680,7 +680,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -761,7 +760,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1014,15 +1012,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1160,7 +1149,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1313,7 +1302,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -5421,9 +5409,9 @@ subdirs="$subdirs opensshlib"
 
 # The following modules rely on crypto functions which rely on OpenSSL, so
 # build them only in case the system has OpenSSL.
-MODULES_SRCS="ncrack_ssh.cc ncrack_smb.cc ncrack_rdp.cc ncrack_sip.cc \
+MODULES_SRCS="ncrack_ssh.cc ncrack_smb.cc ncrack_smb2.cc ncrack_rdp.cc ncrack_sip.cc \
 ncrack_psql.cc ncrack_mysql.cc ncrack_winrm.cc ncrack_mongodb.cc"
-MODULES_OBJS="ncrack_ssh.o ncrack_smb.o ncrack_rdp.o ncrack_sip.o \
+MODULES_OBJS="ncrack_ssh.o ncrack_smb.o ncrack_smb2.o ncrack_rdp.o ncrack_sip.o \
 ncrack_psql.o ncrack_mysql.o ncrack_winrm.o ncrack_mongodb.o"
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -333,9 +333,9 @@ AC_CONFIG_SUBDIRS(opensshlib)
 
 # The following modules rely on crypto functions which rely on OpenSSL, so
 # build them only in case the system has OpenSSL.
-MODULES_SRCS="ncrack_ssh.cc ncrack_smb.cc ncrack_rdp.cc ncrack_sip.cc \
+MODULES_SRCS="ncrack_ssh.cc ncrack_smb.cc ncrack_smb2.cc ncrack_rdp.cc ncrack_sip.cc \
 ncrack_psql.cc ncrack_mysql.cc ncrack_winrm.cc ncrack_mongodb.cc"
-MODULES_OBJS="ncrack_ssh.o ncrack_smb.o ncrack_rdp.o ncrack_sip.o \
+MODULES_OBJS="ncrack_ssh.o ncrack_smb.o ncrack_smb2.o ncrack_rdp.o ncrack_sip.o \
 ncrack_psql.o ncrack_mysql.o ncrack_winrm.o ncrack_mongodb.o"
 
 fi

--- a/crypto.cc
+++ b/crypto.cc
@@ -270,6 +270,7 @@ ntlm_create_hash(const char *password, uint8_t result[16])
   MD4_Init(&ntlm);
   MD4_Update(&ntlm, unicode, strlen(password) * 2);
   MD4_Final(result, &ntlm);
+  free(unicode);
 }
 
 

--- a/nbase/configure
+++ b/nbase/configure
@@ -659,7 +659,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -733,7 +732,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -986,15 +984,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1132,7 +1121,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1285,7 +1274,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/nbase/nbase_config.h.in
+++ b/nbase/nbase_config.h.in
@@ -1,276 +1,261 @@
+/* nbase_config.h.in.  Generated from configure.ac by autoheader.  */
 
-/***************************************************************************
- * nbase_config.h.in -- Autoconf uses this template, combined with the     *
- * configure script knowledge about system capabilities, to build the      *
- * nbase_config.h file that lets nbase (and libraries that call it) better *
- * understand system particulars.                                          *
- *                                                                         *
- ***********************IMPORTANT NMAP LICENSE TERMS************************
- *                                                                         *
- * The Nmap Security Scanner is (C) 1996-2018 Insecure.Com LLC ("The Nmap  *
- * Project"). Nmap is also a registered trademark of the Nmap Project.     *
- * This program is free software; you may redistribute and/or modify it    *
- * under the terms of the GNU General Public License as published by the   *
- * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
- * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
- * right to use, modify, and redistribute this software under certain      *
- * conditions.  If you wish to embed Nmap technology into proprietary      *
- * software, we sell alternative licenses (contact sales@nmap.com).        *
- * Dozens of software vendors already license Nmap technology such as      *
- * host discovery, port scanning, OS detection, version detection, and     *
- * the Nmap Scripting Engine.                                              *
- *                                                                         *
- * Note that the GPL places important restrictions on "derivative works",  *
- * yet it does not provide a detailed definition of that term.  To avoid   *
- * misunderstandings, we interpret that term as broadly as copyright law   *
- * allows.  For example, we consider an application to constitute a        *
- * derivative work for the purpose of this license if it does any of the   *
- * following with any software or content covered by this license          *
- * ("Covered Software"):                                                   *
- *                                                                         *
- * o Integrates source code from Covered Software.                         *
- *                                                                         *
- * o Reads or includes copyrighted data files, such as Nmap's nmap-os-db   *
- * or nmap-service-probes.                                                 *
- *                                                                         *
- * o Is designed specifically to execute Covered Software and parse the    *
- * results (as opposed to typical shell or execution-menu apps, which will *
- * execute anything you tell them to).                                     *
- *                                                                         *
- * o Includes Covered Software in a proprietary executable installer.  The *
- * installers produced by InstallShield are an example of this.  Including *
- * Nmap with other software in compressed or archival form does not        *
- * trigger this provision, provided appropriate open source decompression  *
- * or de-archiving software is widely available for no charge.  For the    *
- * purposes of this license, an installer is considered to include Covered *
- * Software even if it actually retrieves a copy of Covered Software from  *
- * another source during runtime (such as by downloading it from the       *
- * Internet).                                                              *
- *                                                                         *
- * o Links (statically or dynamically) to a library which does any of the  *
- * above.                                                                  *
- *                                                                         *
- * o Executes a helper program, module, or script to do any of the above.  *
- *                                                                         *
- * This list is not exclusive, but is meant to clarify our interpretation  *
- * of derived works with some common examples.  Other people may interpret *
- * the plain GPL differently, so we consider this a special exception to   *
- * the GPL that we apply to Covered Software.  Works which meet any of     *
- * these conditions must conform to all of the terms of this license,      *
- * particularly including the GPL Section 3 requirements of providing      *
- * source code and allowing free redistribution of the work as a whole.    *
- *                                                                         *
- * As another special exception to the GPL terms, the Nmap Project grants  *
- * permission to link the code of this program with any version of the     *
- * OpenSSL library which is distributed under a license identical to that  *
- * listed in the included docs/licenses/OpenSSL.txt file, and distribute   *
- * linked combinations including the two.                                  *
- *                                                                         *
- * The Nmap Project has permission to redistribute Npcap, a packet         *
- * capturing driver and library for the Microsoft Windows platform.        *
- * Npcap is a separate work with it's own license rather than this Nmap    *
- * license.  Since the Npcap license does not permit redistribution        *
- * without special permission, our Nmap Windows binary packages which      *
- * contain Npcap may not be redistributed without special permission.      *
- *                                                                         *
- * Any redistribution of Covered Software, including any derived works,    *
- * must obey and carry forward all of the terms of this license, including *
- * obeying all GPL rules and restrictions.  For example, source code of    *
- * the whole work must be provided and free redistribution must be         *
- * allowed.  All GPL references to "this License", are to be treated as    *
- * including the terms and conditions of this license text as well.        *
- *                                                                         *
- * Because this license imposes special exceptions to the GPL, Covered     *
- * Work may not be combined (even as part of a larger work) with plain GPL *
- * software.  The terms, conditions, and exceptions of this license must   *
- * be included as well.  This license is incompatible with some other open *
- * source licenses as well.  In some cases we can relicense portions of    *
- * Nmap or grant special permissions to use it in other open source        *
- * software.  Please contact fyodor@nmap.org with any such requests.       *
- * Similarly, we don't incorporate incompatible open source software into  *
- * Covered Software without special permission from the copyright holders. *
- *                                                                         *
- * If you have any questions about the licensing restrictions on using     *
- * Nmap in other works, we are happy to help.  As mentioned above, we also *
- * offer an alternative license to integrate Nmap into proprietary         *
- * applications and appliances.  These contracts have been sold to dozens  *
- * of software vendors, and generally include a perpetual license as well  *
- * as providing support and updates.  They also fund the continued         *
- * development of Nmap.  Please email sales@nmap.com for further           *
- * information.                                                            *
- *                                                                         *
- * If you have received a written license agreement or contract for        *
- * Covered Software stating terms other than these, you may choose to use  *
- * and redistribute Covered Software under those terms instead of these.   *
- *                                                                         *
- * Source is provided to this software because we believe users have a     *
- * right to know exactly what a program is going to do before they run it. *
- * This also allows you to audit the software for security holes.          *
- *                                                                         *
- * Source code also allows you to port Nmap to new platforms, fix bugs,    *
- * and add new features.  You are highly encouraged to send your changes   *
- * to the dev@nmap.org mailing list for possible incorporation into the    *
- * main distribution.  By sending these changes to Fyodor or one of the    *
- * Insecure.Org development mailing lists, or checking them into the Nmap  *
- * source code repository, it is understood (unless you specify            *
- * otherwise) that you are offering the Nmap Project the unlimited,        *
- * non-exclusive right to reuse, modify, and relicense the code.  Nmap     *
- * will always be available Open Source, but this is important because     *
- * the inability to relicense code has caused devastating problems for     *
- * other Free Software projects (such as KDE and NASM).  We also           *
- * occasionally relicense the code to third parties as discussed above.    *
- * If you wish to specify special license conditions of your               *
- * contributions, just say so when you send them.                          *
- *                                                                         *
- * This program is distributed in the hope that it will be useful, but     *
- * WITHOUT ANY WARRANTY; without even the implied warranty of              *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the Nmap      *
- * license file for more details (it's in a COPYING file included with     *
- * Nmap, and also available from https://svn.nmap.org/nmap/COPYING)        *
- *                                                                         *
- ***************************************************************************/
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
 
-/* $Id$ */
-#ifndef NBASE_CONFIG_H
-#define NBASE_CONFIG_H
+/* Define if AF_INET6 is defined */
+#undef HAVE_AF_INET6
 
-#undef HAVE_USLEEP
-
-#undef HAVE_NANOSLEEP
-
-#undef HAVE_STRUCT_ICMP
-
-#undef HAVE_IP_IP_SUM
-
-#undef inline
-
-#undef STDC_HEADERS
-
-#undef HAVE_STRING_H
-
-#undef HAVE_NETDB_H
-
-#undef HAVE_GETOPT_H
-
-#undef HAVE_UNISTD_H
-
-#undef HAVE_STRINGS_H
-
-#undef HAVE_BSTRING_H
-
-#undef WORDS_BIGENDIAN
-
-#undef HAVE_MEMORY_H
-
-#undef HAVE_LIBIBERTY_H
-
-#undef HAVE_FCNTL_H
-
-#undef HAVE_ERRNO_H
-
-/* both bzero() and memcpy() are used in the source */
-#undef HAVE_BZERO
-#undef HAVE_MEMCPY
-#undef HAVE_STRERROR
-
-#undef HAVE_SYS_PARAM_H
-
-#undef HAVE_SYS_SELECT_H
-
-#undef HAVE_SYS_SOCKIO_H
-
-#undef HAVE_SYS_SOCKET_H
-
-#undef HAVE_SYS_WAIT_H
-
-#undef HAVE_NET_IF_H
-
-#undef BSD_NETWORKING
-
-#undef HAVE_STRCASESTR
-
-#undef HAVE_STRCASECMP
-
-#undef HAVE_STRNCASECMP
-
-#undef HAVE_GETTIMEOFDAY
-
-#undef HAVE_SLEEP
-
-#undef HAVE_SIGNAL
-
-#undef HAVE_GETOPT
-
-#undef HAVE_GETOPT_LONG_ONLY
-
-#undef HAVE_SOCKADDR_SA_LEN
-
-#undef HAVE_NETINET_IF_ETHER_H
-
-#undef HAVE_NETINET_IN_H
-
-#undef HAVE_SYS_TIME_H
-
-#undef PWD_H
-
+/* Define to 1 if you have the <arpa/inet.h> header file. */
 #undef HAVE_ARPA_INET_H
 
-#undef HAVE_SYS_RESOURCE_H
+/* Define to 1 if you have the `asnprintf' function. */
+#undef HAVE_ASNPRINTF
 
-#undef HAVE_INTTYPES_H
+/* Define to 1 if you have the `asprintf' function. */
+#undef HAVE_ASPRINTF
 
-#undef HAVE_MACH_O_DYLD_H
+/* Define to 1 if you have the <errno.h> header file. */
+#undef HAVE_ERRNO_H
 
-#undef HAVE_SYS_STAT_H
+/* Define to 1 if you have the <fcntl.h> header file. */
+#undef HAVE_FCNTL_H
 
-#undef SPRINTF_RETURNS_STRING
-
-#undef STUPID_SOLARIS_CHECKSUM_BUG
-
-/* IPv6 stuff */
-#undef HAVE_IPV6
-#undef HAVE_AF_INET6
-#undef HAVE_SOCKADDR_IN6
-#undef HAVE_SOCKADDR_STORAGE
-#undef HAVE_GETADDRINFO
+/* Define to 1 if you have the `gai_strerror' function. */
 #undef HAVE_GAI_STRERROR
+
+/* Define if getaddrinfo exists and works well enough for APR */
+#undef HAVE_GETADDRINFO
+
+/* Define if getnameinfo exists */
 #undef HAVE_GETNAMEINFO
+
+/* Define to 1 if you have the `getopt' function. */
+#undef HAVE_GETOPT
+
+/* Define to 1 if you have the <getopt.h> header file. */
+#undef HAVE_GETOPT_H
+
+/* Define to 1 if you have the `getopt_long_only' function. */
+#undef HAVE_GETOPT_LONG_ONLY
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#undef HAVE_GETTIMEOFDAY
+
+/* Define to 1 if you have the `inet_ntop' function. */
 #undef HAVE_INET_NTOP
+
+/* Define to 1 if you have the `inet_pton' function. */
 #undef HAVE_INET_PTON
 
-#undef int8_t
-#undef int16_t
-#undef int32_t
-#undef int64_t
-#undef uint8_t
-#undef uint16_t
-#undef uint32_t
-#undef uint64_t
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
 
+/* define if IPv6 is available */
+#undef HAVE_IPV6
+
+/* Define to 1 if you have the `crypto' library (-lcrypto). */
+#undef HAVE_LIBCRYPTO
+
+/* Define to 1 if you have the `ssl' library (-lssl). */
+#undef HAVE_LIBSSL
+
+/* Define to 1 if you have the <mach-o/dyld.h> header file. */
+#undef HAVE_MACH_O_DYLD_H
+
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
+
+/* Define to 1 if you have the `nanosleep' function. */
+#undef HAVE_NANOSLEEP
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#undef HAVE_NETDB_H
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#undef HAVE_NETINET_IN_H
+
+/* Define to 1 if you have the <net/if.h> header file. */
+#undef HAVE_NET_IF_H
+
+/* define if libssl is available */
+#undef HAVE_OPENSSL
+
+/* Define if you have /proc/self/exe */
+#undef HAVE_PROC_SELF_EXE
+
+/* Define to 1 if you have the `signal' function. */
+#undef HAVE_SIGNAL
+
+/* Define to 1 if you have the `sleep' function. */
+#undef HAVE_SLEEP
+
+/* Define to 1 if you have the `snprintf' function. */
 #undef HAVE_SNPRINTF
+
+/* Define if struct sockaddr_in6 exists */
+#undef HAVE_SOCKADDR_IN6
+
+/* define if sockaddr has sa_len member */
+#undef HAVE_SOCKADDR_SA_LEN
+
+/* Define if struct sockaddr_storage exists */
+#undef HAVE_SOCKADDR_STORAGE
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the `strcasecmp' function. */
+#undef HAVE_STRCASECMP
+
+/* Define to 1 if you have the `strcasestr' function. */
+#undef HAVE_STRCASESTR
+
+/* Define to 1 if you have the `strerror' function. */
+#undef HAVE_STRERROR
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define to 1 if you have the `strncasecmp' function. */
+#undef HAVE_STRNCASECMP
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#undef HAVE_SYS_PARAM_H
+
+/* Define to 1 if you have the <sys/resource.h> header file. */
+#undef HAVE_SYS_RESOURCE_H
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+#undef HAVE_SYS_SELECT_H
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#undef HAVE_SYS_SOCKET_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#undef HAVE_SYS_TIME_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <sys/wait.h> header file. */
+#undef HAVE_SYS_WAIT_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
+
+/* Define to 1 if you have the `usleep' function. */
+#undef HAVE_USLEEP
+
+/* Define to 1 if you have the `vasnprintf' function. */
 #undef HAVE_VASNPRINTF
-#undef HAVE_ASPRINTF
+
+/* Define to 1 if you have the `vasprintf' function. */
 #undef HAVE_VASPRINTF
-#undef HAVE_VFPRINTF
+
+/* Define to 1 if you have the `vsnprintf' function. */
 #undef HAVE_VSNPRINTF
-#undef NEED_SNPRINTF_PROTO
-#undef NEED_VSNPRINTF_PROTO
+
+/* Define to 1 if you have the file `/proc/self/exe'. */
+#undef HAVE__PROC_SELF_EXE
 
 /* define if your compiler has __attribute__ */
 #undef HAVE___ATTRIBUTE__
 
-#undef HAVE_OPENSSL
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
 
-#undef HAVE_PROC_SELF_EXE
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
 
-#undef LINUX
-#undef FREEBSD
-#undef OPENBSD
-#undef SOLARIS
-#undef SUNOS
-#undef BSDI
-#undef IRIX
-#undef HPUX
-#undef NETBSD
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
 
-#endif /* NBASE_CONFIG_H */
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS
+
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+#undef TIME_WITH_SYS_TIME
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif
+
+/* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+#undef _UINT32_T
+
+/* Define for Solaris 2.5.1 so the uint64_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+#undef _UINT64_T
+
+/* Define for Solaris 2.5.1 so the uint8_t typedef from <sys/synch.h>,
+   <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the
+   #define below would cause a syntax error. */
+#undef _UINT8_T
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+#undef inline
+#endif
+
+/* Define to the type of a signed integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+#undef int16_t
+
+/* Define to the type of a signed integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+#undef int32_t
+
+/* Define to the type of a signed integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+#undef int64_t
+
+/* Define to the type of a signed integer type of width exactly 8 bits if such
+   a type exists and the standard includes do not define it. */
+#undef int8_t
+
+/* Define to the type of an unsigned integer type of width exactly 16 bits if
+   such a type exists and the standard includes do not define it. */
+#undef uint16_t
+
+/* Define to the type of an unsigned integer type of width exactly 32 bits if
+   such a type exists and the standard includes do not define it. */
+#undef uint32_t
+
+/* Define to the type of an unsigned integer type of width exactly 64 bits if
+   such a type exists and the standard includes do not define it. */
+#undef uint64_t
+
+/* Define to the type of an unsigned integer type of width exactly 8 bits if
+   such a type exists and the standard includes do not define it. */
+#undef uint8_t

--- a/ncrack-services
+++ b/ncrack-services
@@ -15,6 +15,7 @@ pop3 110/tcp
 imap 143/tcp
 netbios-ssn 445/tcp
 smb 445/tcp
+smb2 445/tcp
 smb 139/tcp
 https 443/tcp
 owa 443/tcp

--- a/ncrack.cc
+++ b/ncrack.cc
@@ -816,6 +816,9 @@ call_module(nsock_pool nsp, Connection *con)
     ncrack_rdp(nsp, con);
   else if (!strcmp(name, "smb") || !strcmp(name, "netbios-ssn"))
     ncrack_smb(nsp, con);
+  else if (!strcmp(name, "smb2"))
+    ncrack_smb2(nsp, con);
+
 #endif
   else
     fatal("Invalid service module: %s", name);

--- a/ncrack_config.h.in
+++ b/ncrack_config.h.in
@@ -1,233 +1,100 @@
-/***************************************************************************
- * nmap_config.h.in -- Autoconf uses this template, combined with the      *
- * configure script knowledge about system capabilities, to build this     *
- * include file that lets nmap better understand system particulars.       *
- *                                                                         *
- ***********************IMPORTANT NMAP LICENSE TERMS************************
- *                                                                         *
- * The Nmap Security Scanner is (C) 1996-2018 Insecure.Com LLC ("The Nmap  *
- * Project"). Nmap is also a registered trademark of the Nmap Project.     *
- * This program is free software; you may redistribute and/or modify it    *
- * under the terms of the GNU General Public License as published by the   *
- * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
- * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
- * right to use, modify, and redistribute this software under certain      *
- * conditions.  If you wish to embed Nmap technology into proprietary      *
- * software, we sell alternative licenses (contact sales@nmap.com).        *
- * Dozens of software vendors already license Nmap technology such as      *
- * host discovery, port scanning, OS detection, version detection, and     *
- * the Nmap Scripting Engine.                                              *
- *                                                                         *
- * Note that the GPL places important restrictions on "derivative works",  *
- * yet it does not provide a detailed definition of that term.  To avoid   *
- * misunderstandings, we interpret that term as broadly as copyright law   *
- * allows.  For example, we consider an application to constitute a        *
- * derivative work for the purpose of this license if it does any of the   *
- * following with any software or content covered by this license          *
- * ("Covered Software"):                                                   *
- *                                                                         *
- * o Integrates source code from Covered Software.                         *
- *                                                                         *
- * o Reads or includes copyrighted data files, such as Nmap's nmap-os-db   *
- * or nmap-service-probes.                                                 *
- *                                                                         *
- * o Is designed specifically to execute Covered Software and parse the    *
- * results (as opposed to typical shell or execution-menu apps, which will *
- * execute anything you tell them to).                                     *
- *                                                                         *
- * o Includes Covered Software in a proprietary executable installer.  The *
- * installers produced by InstallShield are an example of this.  Including *
- * Nmap with other software in compressed or archival form does not        *
- * trigger this provision, provided appropriate open source decompression  *
- * or de-archiving software is widely available for no charge.  For the    *
- * purposes of this license, an installer is considered to include Covered *
- * Software even if it actually retrieves a copy of Covered Software from  *
- * another source during runtime (such as by downloading it from the       *
- * Internet).                                                              *
- *                                                                         *
- * o Links (statically or dynamically) to a library which does any of the  *
- * above.                                                                  *
- *                                                                         *
- * o Executes a helper program, module, or script to do any of the above.  *
- *                                                                         *
- * This list is not exclusive, but is meant to clarify our interpretation  *
- * of derived works with some common examples.  Other people may interpret *
- * the plain GPL differently, so we consider this a special exception to   *
- * the GPL that we apply to Covered Software.  Works which meet any of     *
- * these conditions must conform to all of the terms of this license,      *
- * particularly including the GPL Section 3 requirements of providing      *
- * source code and allowing free redistribution of the work as a whole.    *
- *                                                                         *
- * As another special exception to the GPL terms, the Nmap Project grants  *
- * permission to link the code of this program with any version of the     *
- * OpenSSL library which is distributed under a license identical to that  *
- * listed in the included docs/licenses/OpenSSL.txt file, and distribute   *
- * linked combinations including the two.                                  *
- *                                                                         *
- * The Nmap Project has permission to redistribute Npcap, a packet         *
- * capturing driver and library for the Microsoft Windows platform.        *
- * Npcap is a separate work with it's own license rather than this Nmap    *
- * license.  Since the Npcap license does not permit redistribution        *
- * without special permission, our Nmap Windows binary packages which      *
- * contain Npcap may not be redistributed without special permission.      *
- *                                                                         *
- * Any redistribution of Covered Software, including any derived works,    *
- * must obey and carry forward all of the terms of this license, including *
- * obeying all GPL rules and restrictions.  For example, source code of    *
- * the whole work must be provided and free redistribution must be         *
- * allowed.  All GPL references to "this License", are to be treated as    *
- * including the terms and conditions of this license text as well.        *
- *                                                                         *
- * Because this license imposes special exceptions to the GPL, Covered     *
- * Work may not be combined (even as part of a larger work) with plain GPL *
- * software.  The terms, conditions, and exceptions of this license must   *
- * be included as well.  This license is incompatible with some other open *
- * source licenses as well.  In some cases we can relicense portions of    *
- * Nmap or grant special permissions to use it in other open source        *
- * software.  Please contact fyodor@nmap.org with any such requests.       *
- * Similarly, we don't incorporate incompatible open source software into  *
- * Covered Software without special permission from the copyright holders. *
- *                                                                         *
- * If you have any questions about the licensing restrictions on using     *
- * Nmap in other works, we are happy to help.  As mentioned above, we also *
- * offer an alternative license to integrate Nmap into proprietary         *
- * applications and appliances.  These contracts have been sold to dozens  *
- * of software vendors, and generally include a perpetual license as well  *
- * as providing support and updates.  They also fund the continued         *
- * development of Nmap.  Please email sales@nmap.com for further           *
- * information.                                                            *
- *                                                                         *
- * If you have received a written license agreement or contract for        *
- * Covered Software stating terms other than these, you may choose to use  *
- * and redistribute Covered Software under those terms instead of these.   *
- *                                                                         *
- * Source is provided to this software because we believe users have a     *
- * right to know exactly what a program is going to do before they run it. *
- * This also allows you to audit the software for security holes.          *
- *                                                                         *
- * Source code also allows you to port Nmap to new platforms, fix bugs,    *
- * and add new features.  You are highly encouraged to send your changes   *
- * to the dev@nmap.org mailing list for possible incorporation into the    *
- * main distribution.  By sending these changes to Fyodor or one of the    *
- * Insecure.Org development mailing lists, or checking them into the Nmap  *
- * source code repository, it is understood (unless you specify            *
- * otherwise) that you are offering the Nmap Project the unlimited,        *
- * non-exclusive right to reuse, modify, and relicense the code.  Nmap     *
- * will always be available Open Source, but this is important because     *
- * the inability to relicense code has caused devastating problems for     *
- * other Free Software projects (such as KDE and NASM).  We also           *
- * occasionally relicense the code to third parties as discussed above.    *
- * If you wish to specify special license conditions of your               *
- * contributions, just say so when you send them.                          *
- *                                                                         *
- * This program is distributed in the hope that it will be useful, but     *
- * WITHOUT ANY WARRANTY; without even the implied warranty of              *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the Nmap      *
- * license file for more details (it's in a COPYING file included with     *
- * Nmap, and also available from https://svn.nmap.org/nmap/COPYING)        *
- *                                                                         *
- ***************************************************************************/
+/* ncrack_config.h.in.  Generated from configure.ac by autoheader.  */
 
-/* $Id: nmap_config.h.in 12955 2009-04-15 00:37:03Z fyodor $ */
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
 
-#ifndef CONFIG_H
-#define CONFIG_H
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
 
-#undef HAVE_SIGNAL
-
-#undef HAVE_STRUCT_IP
-
-#undef HAVE_NANOSLEEP
-
-#undef HAVE_STRUCT_ICMP
-
-#undef HAVE_IP_IP_SUM
-
-#undef inline
-
-#undef STDC_HEADERS
-
-#undef HAVE_UNISTD_H
-
-#undef HAVE_STRING_H
-
-#undef HAVE_GETOPT_H
-
-#undef HAVE_STRINGS_H
-
-#undef HAVE_PWD_H
-
-#undef HAVE_BSTRING_H
-
-#undef WORDS_BIGENDIAN
-
+/* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 
-/* both bzero() and memcpy() are used in the source */
-#undef HAVE_BZERO
-#undef HAVE_MEMCPY
-#undef HAVE_STRERROR
-
-#undef HAVE_SYS_PARAM_H
-
-#undef HAVE_SYS_SOCKIO_H
-
-#undef HAVE_SYS_STAT_H
-
-#undef HAVE_FCNTL_H
-
-#undef HAVE_TERMIOS_H
-
-#undef HAVE_PCRE_H
-
-#undef HAVE_PCRE_PCRE_H
-
-#undef BSD_NETWORKING
-
-#undef HAVE_STRCASESTR
-
-#undef IN_ADDR_DEEPSTRUCT
-
-#undef HAVE_SOCKADDR_SA_LEN
-
-#undef HAVE_NETINET_IF_ETHER_H
-
+/* OpenSSL is available */
 #undef HAVE_OPENSSL
 
-#undef STUPID_SOLARIS_CHECKSUM_BUG
+/* Define to 1 if you have the <pwd.h> header file. */
+#undef HAVE_PWD_H
 
-#undef SPRINTF_RETURNS_STRING
+/* Define to 1 if you have the `signal' function. */
+#undef HAVE_SIGNAL
 
-#undef TIME_WITH_SYS_TIME
-#undef HAVE_SYS_TIME_H
+/* struct sockaddr has sa_len member */
+#undef HAVE_SOCKADDR_SA_LEN
 
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the `strerror' function. */
+#undef HAVE_STRERROR
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/sockio.h> header file. */
+#undef HAVE_SYS_SOCKIO_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <termios.h> header file. */
+#undef HAVE_TERMIOS_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
+
+/* struct in_addr is a whacky huge structure */
+#undef IN_ADDR_DEEPSTRUCT
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif
+
+/* Use __FILE__ since __FUNCTION__ is not available */
+#undef __func__
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+#undef inline
+#endif
+
+/* Type of 6th argument to recvfrom() */
 #undef recvfrom6_t
-
-#undef NEED_USLEEP_PROTO
-#undef NEED_GETHOSTNAME_PROTO
-
-#ifdef NEED_USLEEP_PROTO
-#ifdef __cplusplus
-extern "C" int usleep (unsigned int);
-#endif
-#endif
-
-#ifdef NEED_GETHOSTNAME_PROTO
-#ifdef __cplusplus
-extern "C" int gethostname (char *, unsigned int);
-#endif
-#endif
-
-#undef DEC
-#undef LINUX
-#undef FREEBSD
-#undef OPENBSD
-#undef SOLARIS
-#undef SUNOS
-#undef BSDI
-#undef IRIX
-#undef HPUX
-#undef NETBSD
-#undef MACOSX
-
-#endif /* CONFIG_H */

--- a/nsock/include/nsock_config.h.in
+++ b/nsock/include/nsock_config.h.in
@@ -1,92 +1,136 @@
-/***************************************************************************
- * nsock_config.h.in -- Autoconf uses this template, combined with the     *
- * configure script knowledge about system capabilities, to build the      *
- * nsock_config.h include file that lets nsock better understand system    *
- *  particulars.                                                           *
- *                                                                         *
- ***********************IMPORTANT NSOCK LICENSE TERMS***********************
- *                                                                         *
- * The nsock parallel socket event library is (C) 1999-2017 Insecure.Com   *
- * LLC This library is free software; you may redistribute and/or          *
- * modify it under the terms of the GNU General Public License as          *
- * published by the Free Software Foundation; Version 2.  This guarantees  *
- * your right to use, modify, and redistribute this software under certain *
- * conditions.  If this license is unacceptable to you, Insecure.Com LLC   *
- * may be willing to sell alternative licenses (contact                    *
- * sales@insecure.com ).                                                   *
- *                                                                         *
- * As a special exception to the GPL terms, Insecure.Com LLC grants        *
- * permission to link the code of this program with any version of the     *
- * OpenSSL library which is distributed under a license identical to that  *
- * listed in the included docs/licenses/OpenSSL.txt file, and distribute   *
- * linked combinations including the two. You must obey the GNU GPL in all *
- * respects for all of the code used other than OpenSSL.  If you modify    *
- * this file, you may extend this exception to your version of the file,   *
- * but you are not obligated to do so.                                     *
- *                                                                         *
- * If you received these files with a written license agreement stating    *
- * terms other than the (GPL) terms above, then that alternative license   *
- * agreement takes precedence over this comment.                           *
- *                                                                         *
- * Source is provided to this software because we believe users have a     *
- * right to know exactly what a program is going to do before they run it. *
- * This also allows you to audit the software for security holes.          *
- *                                                                         *
- * Source code also allows you to port Nmap to new platforms, fix bugs,    *
- * and add new features.  You are highly encouraged to send your changes   *
- * to the dev@nmap.org mailing list for possible incorporation into the    *
- * main distribution.  By sending these changes to Fyodor or one of the    *
- * Insecure.Org development mailing lists, or checking them into the Nmap  *
- * source code repository, it is understood (unless you specify otherwise) *
- * that you are offering the Nmap Project (Insecure.Com LLC) the           *
- * unlimited, non-exclusive right to reuse, modify, and relicense the      *
- * code.  Nmap will always be available Open Source, but this is important *
- * because the inability to relicense code has caused devastating problems *
- * for other Free Software projects (such as KDE and NASM).  We also       *
- * occasionally relicense the code to third parties as discussed above.    *
- * If you wish to specify special license conditions of your               *
- * contributions, just say so when you send them.                          *
- *                                                                         *
- * This program is distributed in the hope that it will be useful, but     *
- * WITHOUT ANY WARRANTY; without even the implied warranty of              *
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU       *
- * General Public License v2.0 for more details                            *
- * (http://www.gnu.org/licenses/gpl-2.0.html).                             *
- *                                                                         *
- ***************************************************************************/
+/* ../include/nsock_config.h.in.  Generated from configure.ac by autoheader.  */
 
-/* $Id$ */
-
-#undef HAVE_PCAP
-#undef DEC
-#undef LINUX
-#undef FREEBSD
-#undef OPENBSD
-#undef SOLARIS
-#undef SUNOS
+/* BSD/OS */
 #undef BSDI
-#undef IRIX
-#undef HPUX
-#undef NETBSD
-#undef MACOSX
 
-#undef SOLARIS_BPF_PCAP_CAPTURE
+/* DEC Alpha */
+#undef DEC
 
+/* FreeBSD */
+#undef FREEBSD
+
+/* SSL ALPN protos support */
+#undef HAVE_ALPN_SUPPORT
+
+/* DTLS_client_method available */
+#undef HAVE_DTLS_CLIENT_METHOD
+
+/* epoll is available */
+#undef HAVE_EPOLL
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
+
+/* Define to 1 if you have the `kevent' function. */
+#undef HAVE_KEVENT
+
+/* Define to 1 if you have the `kqueue' function. */
+#undef HAVE_KQUEUE
+
+/* Define to 1 if you have the `nsl' library (-lnsl). */
+#undef HAVE_LIBNSL
+
+/* Define to 1 if you have the `posix4' library (-lposix4). */
+#undef HAVE_LIBPOSIX4
+
+/* Define to 1 if you have the `socket' library (-lsocket). */
+#undef HAVE_LIBSOCKET
+
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#undef HAVE_NETDB_H
+
+/* Define to 1 if you have the <net/bpf.h> header file. */
 #undef HAVE_NET_BPF_H
+
+/* openssl is available */
+#undef HAVE_OPENSSL
+
+/* libpcap is available */
+#undef HAVE_PCAP
+
+/* poll is available */
+#undef HAVE_POLL
+
+/* SSL_set_tlsext_host_name available */
+#undef HAVE_SSL_SET_TLSEXT_HOST_NAME
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
 #undef HAVE_SYS_IOCTL_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
 
 /* Define to 1 if you have the <sys/un.h> header file. */
 #undef HAVE_SYS_UN_H
 
-#undef HAVE_NETDB_H
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
 
-#undef HAVE_OPENSSL
-#undef HAVE_SSL_SET_TLSEXT_HOST_NAME
-#undef HAVE_DTLS_CLIENT_METHOD
-#undef HAVE_ALPN_SUPPORT
+/* HP-UX */
+#undef HPUX
 
-#undef HAVE_EPOLL
-#undef HAVE_POLL
-#undef HAVE_KQUEUE
+/* IRIX */
+#undef IRIX
 
+/* Linux */
+#undef LINUX
+
+/* Apple OS X */
+#undef MACOSX
+
+/* NetBSD */
+#undef NETBSD
+
+/* OpenBSD */
+#undef OPENBSD
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Possibly using libpcap prior to 1.1.0. */
 #undef PCAP_NETMASK_UNKNOWN
+
+/* Sun/Oracle Solaris */
+#undef SOLARIS
+
+/* BPF packet capture on Solaris */
+#undef SOLARIS_BPF_PCAP_CAPTURE
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS
+
+/* SunOS 4 */
+#undef SUNOS

--- a/nsock/src/aclocal.m4
+++ b/nsock/src/aclocal.m4
@@ -1,8 +1,7 @@
-# generated automatically by aclocal 1.11.6 -*- Autoconf -*-
+# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
 
-# Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004,
-# 2005, 2006, 2007, 2008, 2009, 2010, 2011 Free Software Foundation,
-# Inc.
+# Copyright (C) 1996-2017 Free Software Foundation, Inc.
+
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
 # with or without modifications, as long as this notice is preserved.
@@ -12,4 +11,5 @@
 # even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.
 
+m4_ifndef([AC_CONFIG_MACRO_DIRS], [m4_defun([_AM_CONFIG_MACRO_DIRS], [])m4_defun([AC_CONFIG_MACRO_DIRS], [_AM_CONFIG_MACRO_DIRS($@)])])
 m4_include([acinclude.m4])

--- a/nsock/src/configure
+++ b/nsock/src/configure
@@ -664,7 +664,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -739,7 +738,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -992,15 +990,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1138,7 +1127,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1291,7 +1280,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -2232,17 +2220,23 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
 
+
+
+
 case "$host" in
   *alpha-dec-osf*)
-    $as_echo "#define DEC 1" >>confdefs.h
+
+$as_echo "#define DEC 1" >>confdefs.h
 
     ;;
   *-netbsd* | *-knetbsd*-gnu)
-    $as_echo "#define NETBSD 1" >>confdefs.h
+
+$as_echo "#define NETBSD 1" >>confdefs.h
 
     ;;
   *-openbsd*)
-    $as_echo "#define OPENBSD 1" >>confdefs.h
+
+$as_echo "#define OPENBSD 1" >>confdefs.h
 
     ;;
   *-sgi-irix5*)
@@ -2254,14 +2248,16 @@ case "$host" in
 
     ;;
   *-hpux*)
-    $as_echo "#define HPUX 1" >>confdefs.h
+
+$as_echo "#define HPUX 1" >>confdefs.h
 
     ;;
   *-solaris2.1[1-9]*)
     $as_echo "#define SOLARIS 1" >>confdefs.h
 
     # Solaris 11 and later use BPF packet capture rather than DLPI.
-    $as_echo "#define SOLARIS_BPF_PCAP_CAPTURE 1" >>confdefs.h
+
+$as_echo "#define SOLARIS_BPF_PCAP_CAPTURE 1" >>confdefs.h
 
     ;;
   *-solaris2.0*)
@@ -2297,23 +2293,28 @@ case "$host" in
 
     ;;
   *-sunos4*)
-    $as_echo "#define SUNOS 1" >>confdefs.h
+
+$as_echo "#define SUNOS 1" >>confdefs.h
 
     ;;
   *-linux*)
-    $as_echo "#define LINUX 1" >>confdefs.h
+
+$as_echo "#define LINUX 1" >>confdefs.h
 
     ;;
   *-freebsd* | *-kfreebsd*-gnu | *-dragonfly*)
-    $as_echo "#define FREEBSD 1" >>confdefs.h
+
+$as_echo "#define FREEBSD 1" >>confdefs.h
 
     ;;
   *-bsdi*)
-    $as_echo "#define BSDI 1" >>confdefs.h
+
+$as_echo "#define BSDI 1" >>confdefs.h
 
     ;;
   *-apple-darwin*)
-    $as_echo "#define MACOSX 1" >>confdefs.h
+
+$as_echo "#define MACOSX 1" >>confdefs.h
 
     ;;
 esac
@@ -3628,7 +3629,8 @@ if test "$with_libpcap" != "no" -a "$have_libpcap" = "no"; then
   have_libpcap=yes
 fi
 if test "$have_libpcap" != "no"; then
-  $as_echo "#define HAVE_PCAP 1" >>confdefs.h
+
+$as_echo "#define HAVE_PCAP 1" >>confdefs.h
 
   if test "${LIBPCAP_INC+set}" = "set"; then
     CPPFLAGS="-I$LIBPCAP_INC $CPPFLAGS"
@@ -3721,6 +3723,7 @@ fi
   if test "${ax_cv_have_epoll}" = "yes"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
+
 $as_echo "#define HAVE_EPOLL 1" >>confdefs.h
 
 else
@@ -3757,6 +3760,7 @@ fi
   if test "${ax_cv_have_poll}" = "yes"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
+
 $as_echo "#define HAVE_POLL 1" >>confdefs.h
 
 else
@@ -4898,7 +4902,8 @@ fi
 
 OPENSSL_LIBS=
 if test "$use_openssl" = "yes"; then
-  $as_echo "#define HAVE_OPENSSL 1" >>confdefs.h
+
+$as_echo "#define HAVE_OPENSSL 1" >>confdefs.h
 
   OPENSSL_LIBS="-lssl -lcrypto"
   LIBS_TMP="$LIBS"
@@ -4918,7 +4923,8 @@ SSL_set_tlsext_host_name(NULL, NULL)
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }; $as_echo "#define HAVE_SSL_SET_TLSEXT_HOST_NAME 1" >>confdefs.h
+$as_echo "yes" >&6; };
+$as_echo "#define HAVE_SSL_SET_TLSEXT_HOST_NAME 1" >>confdefs.h
 
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
@@ -4941,7 +4947,8 @@ DTLS_client_method()
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }; $as_echo "#define HAVE_DTLS_CLIENT_METHOD 1" >>confdefs.h
+$as_echo "yes" >&6; };
+$as_echo "#define HAVE_DTLS_CLIENT_METHOD 1" >>confdefs.h
 
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
@@ -4964,7 +4971,8 @@ SSL_set_alpn_protos(NULL, NULL, 0)
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }; $as_echo "#define HAVE_ALPN_SUPPORT 1" >>confdefs.h
+$as_echo "yes" >&6; };
+$as_echo "#define HAVE_ALPN_SUPPORT 1" >>confdefs.h
 
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5

--- a/ntlmssp.cc
+++ b/ntlmssp.cc
@@ -1,0 +1,657 @@
+/* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+/***************************************************************************
+ * ntlmssp.cc -- ntlmssp auth method                                       *
+ *                                                                         *
+ ***********************IMPORTANT NMAP LICENSE TERMS************************
+ *                                                                         *
+ * The Nmap Security Scanner is (C) 1996-2018 Insecure.Com LLC ("The Nmap  *
+ * Project"). Nmap is also a registered trademark of the Nmap Project.     *
+ * This program is free software; you may redistribute and/or modify it    *
+ * under the terms of the GNU General Public License as published by the   *
+ * Free Software Foundation; Version 2 ("GPL"), BUT ONLY WITH ALL OF THE   *
+ * CLARIFICATIONS AND EXCEPTIONS DESCRIBED HEREIN.  This guarantees your   *
+ * right to use, modify, and redistribute this software under certain      *
+ * conditions.  If you wish to embed Nmap technology into proprietary      *
+ * software, we sell alternative licenses (contact sales@nmap.com).        *
+ * Dozens of software vendors already license Nmap technology such as      *
+ * host discovery, port scanning, OS detection, version detection, and     *
+ * the Nmap Scripting Engine.                                              *
+ *                                                                         *
+ * Note that the GPL places important restrictions on "derivative works",  *
+ * yet it does not provide a detailed definition of that term.  To avoid   *
+ * misunderstandings, we interpret that term as broadly as copyright law   *
+ * allows.  For example, we consider an application to constitute a        *
+ * derivative work for the purpose of this license if it does any of the   *
+ * following with any software or content covered by this license          *
+ * ("Covered Software"):                                                   *
+ *                                                                         *
+ * o Integrates source code from Covered Software.                         *
+ *                                                                         *
+ * o Reads or includes copyrighted data files, such as Nmap's nmap-os-db   *
+ * or nmap-service-probes.                                                 *
+ *                                                                         *
+ * o Is designed specifically to execute Covered Software and parse the    *
+ * results (as opposed to typical shell or execution-menu apps, which will *
+ * execute anything you tell them to).                                     *
+ *                                                                         *
+ * o Includes Covered Software in a proprietary executable installer.  The *
+ * installers produced by InstallShield are an example of this.  Including *
+ * Nmap with other software in compressed or archival form does not        *
+ * trigger this provision, provided appropriate open source decompression  *
+ * or de-archiving software is widely available for no charge.  For the    *
+ * purposes of this license, an installer is considered to include Covered *
+ * Software even if it actually retrieves a copy of Covered Software from  *
+ * another source during runtime (such as by downloading it from the       *
+ * Internet).                                                              *
+ *                                                                         *
+ * o Links (statically or dynamically) to a library which does any of the  *
+ * above.                                                                  *
+ *                                                                         *
+ * o Executes a helper program, module, or script to do any of the above.  *
+ *                                                                         *
+ * This list is not exclusive, but is meant to clarify our interpretation  *
+ * of derived works with some common examples.  Other people may interpret *
+ * the plain GPL differently, so we consider this a special exception to   *
+ * the GPL that we apply to Covered Software.  Works which meet any of     *
+ * these conditions must conform to all of the terms of this license,      *
+ * particularly including the GPL Section 3 requirements of providing      *
+ * source code and allowing free redistribution of the work as a whole.    *
+ *                                                                         *
+ * As another special exception to the GPL terms, the Nmap Project grants  *
+ * permission to link the code of this program with any version of the     *
+ * OpenSSL library which is distributed under a license identical to that  *
+ * listed in the included docs/licenses/OpenSSL.txt file, and distribute   *
+ * linked combinations including the two.                                  *
+ *                                                                         *
+ * The Nmap Project has permission to redistribute Npcap, a packet         *
+ * capturing driver and library for the Microsoft Windows platform.        *
+ * Npcap is a separate work with it's own license rather than this Nmap    *
+ * license.  Since the Npcap license does not permit redistribution        *
+ * without special permission, our Nmap Windows binary packages which      *
+ * contain Npcap may not be redistributed without special permission.      *
+ *                                                                         *
+ * Any redistribution of Covered Software, including any derived works,    *
+ * must obey and carry forward all of the terms of this license, including *
+ * obeying all GPL rules and restrictions.  For example, source code of    *
+ * the whole work must be provided and free redistribution must be         *
+ * allowed.  All GPL references to "this License", are to be treated as    *
+ * including the terms and conditions of this license text as well.        *
+ *                                                                         *
+ * Because this license imposes special exceptions to the GPL, Covered     *
+ * Work may not be combined (even as part of a larger work) with plain GPL *
+ * software.  The terms, conditions, and exceptions of this license must   *
+ * be included as well.  This license is incompatible with some other open *
+ * source licenses as well.  In some cases we can relicense portions of    *
+ * Nmap or grant special permissions to use it in other open source        *
+ * software.  Please contact fyodor@nmap.org with any such requests.       *
+ * Similarly, we don't incorporate incompatible open source software into  *
+ * Covered Software without special permission from the copyright holders. *
+ *                                                                         *
+ * If you have any questions about the licensing restrictions on using     *
+ * Nmap in other works, we are happy to help.  As mentioned above, we also *
+ * offer an alternative license to integrate Nmap into proprietary         *
+ * applications and appliances.  These contracts have been sold to dozens  *
+ * of software vendors, and generally include a perpetual license as well  *
+ * as providing support and updates.  They also fund the continued         *
+ * development of Nmap.  Please email sales@nmap.com for further           *
+ * information.                                                            *
+ *                                                                         *
+ * If you have received a written license agreement or contract for        *
+ * Covered Software stating terms other than these, you may choose to use  *
+ * and redistribute Covered Software under those terms instead of these.   *
+ *                                                                         *
+ * Source is provided to this software because we believe users have a     *
+ * right to know exactly what a program is going to do before they run it. *
+ * This also allows you to audit the software for security holes.          *
+ *                                                                         *
+ * Source code also allows you to port Nmap to new platforms, fix bugs,    *
+ * and add new features.  You are highly encouraged to send your changes   *
+ * to the dev@nmap.org mailing list for possible incorporation into the    *
+ * main distribution.  By sending these changes to Fyodor or one of the    *
+ * Insecure.Org development mailing lists, or checking them into the Nmap  *
+ * source code repository, it is understood (unless you specify            *
+ * otherwise) that you are offering the Nmap Project the unlimited,        *
+ * non-exclusive right to reuse, modify, and relicense the code.  Nmap     *
+ * will always be available Open Source, but this is important because     *
+ * the inability to relicense code has caused devastating problems for     *
+ * other Free Software projects (such as KDE and NASM).  We also           *
+ * occasionally relicense the code to third parties as discussed above.    *
+ * If you wish to specify special license conditions of your               *
+ * contributions, just say so when you send them.                          *
+ *                                                                         *
+ * This program is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the Nmap      *
+ * license file for more details (it's in a COPYING file included with     *
+ * Nmap, and also available from https://svn.nmap.org/nmap/COPYING)        *
+ *                                                                         *
+ ***************************************************************************/
+
+/*
+   Proudly stolen and adapted from libsmb2 -- https://github.com/sahlberg/libsmb2
+   - lazily converted original C code to C++ (mostly casted malloc)
+   - replaced custom crypto with openssl (hmac md5)
+   - replaced custom unicode conv to ncrack routine (unicode_alloc)
+   - replaced custom ntlmv1 routine to ncrack routine (ntlm_create_hash)
+
+   Copyright (C) 2018 by Ronnie Sahlberg <ronniesahlberg@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published by
+   the Free Software Foundation; either version 2.1 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <time.h>
+
+#include <openssl/hmac.h>
+#include <openssl/md4.h>
+#include <openssl/md5.h>
+
+#include "ntlmssp.h"
+
+#include "crypto.h" // ntlm_create_hash
+#include "utils.h" // unicode_alloc
+
+#define SMB2_KEY_SIZE 16
+
+struct auth_data {
+        unsigned char *buf;
+        int len;
+        int allocated;
+
+        int neg_result;
+        unsigned char *ntlm_buf;
+        int ntlm_len;
+
+        const char *user;
+        const char *password;
+        const char *domain;
+        const char *workstation;
+        const char *client_challenge;
+
+        uint8_t exported_session_key[SMB2_KEY_SIZE];
+};
+
+#define NEGOTIATE_MESSAGE      0x00000001
+#define CHALLENGE_MESSAGE      0x00000002
+#define AUTHENTICATION_MESSAGE 0x00000003
+
+#define NTLMSSP_NEGOTIATE_56                               0x80000000
+#define NTLMSSP_NEGOTIATE_128                              0x20000000
+#define NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY         0x00080000
+#define NTLMSSP_TARGET_TYPE_SERVER                         0x00020000
+#define NTLMSSP_NEGOTIATE_ALWAYS_SIGN                      0x00008000
+#define NTLMSSP_NEGOTIATE_NTLM                             0x00000200
+#define NTLMSSP_NEGOTIATE_SIGN                             0x00000010
+#define NTLMSSP_REQUEST_TARGET                             0x00000004
+#define NTLMSSP_NEGOTIATE_OEM                              0x00000002
+#define NTLMSSP_NEGOTIATE_UNICODE                          0x00000001
+#define NTLMSSP_NEGOTIATE_KEY_EXCH                         0x40000000
+
+static uint64_t
+timeval_to_win(struct timeval *tv)
+{
+        return ((uint64_t)tv->tv_sec * 10000000) +
+                116444736000000000 + tv->tv_usec * 10;
+}
+
+void
+ntlmssp_destroy_context(struct auth_data *auth)
+{
+        free(auth->ntlm_buf);
+        free(auth->buf);
+        free(auth);
+}
+
+struct auth_data *
+ntlmssp_init_context(const char *user,
+                     const char *password,
+                     const char *domain,
+                     const char *workstation,
+                     const char *client_challenge)
+{
+        struct auth_data *auth_data = NULL;
+
+        auth_data = (struct auth_data*)malloc(sizeof(struct auth_data));
+        if (auth_data == NULL) {
+                return NULL;
+        }
+        memset(auth_data, 0, sizeof(struct auth_data));
+
+        auth_data->user        = user;
+        auth_data->password    = password;
+        auth_data->domain      = domain;
+        auth_data->workstation = workstation;
+        auth_data->client_challenge = client_challenge;
+
+        memset(auth_data->exported_session_key, 0, SMB2_KEY_SIZE);
+
+        return auth_data;
+}
+
+static int
+encoder(const void *buffer, size_t size, void *ptr)
+{
+        struct auth_data *auth_data = (struct auth_data*)ptr;
+
+        if (size + auth_data->len > auth_data->allocated) {
+                unsigned char *tmp = auth_data->buf;
+
+                auth_data->allocated = 2 * ((size + auth_data->allocated + 256) & ~0xff);
+                auth_data->buf = (unsigned char*)malloc(auth_data->allocated);
+                if (auth_data->buf == NULL) {
+                        free(tmp);
+                        return -1;
+                }
+                memcpy(auth_data->buf, tmp, auth_data->len);
+                free(tmp);
+        }
+
+        memcpy(auth_data->buf + auth_data->len, buffer, size);
+        auth_data->len += size;
+
+        return 0;
+}
+
+static int
+ntlm_negotiate_message(struct auth_data *auth_data)
+{
+        unsigned char ntlm[32];
+        uint32_t u32;
+
+        memset(ntlm, 0, 32);
+        memcpy(ntlm, "NTLMSSP", 8);
+
+        u32 = htole32(NEGOTIATE_MESSAGE);
+        memcpy(&ntlm[8], &u32, 4);
+
+        u32 = htole32(NTLMSSP_NEGOTIATE_56|NTLMSSP_NEGOTIATE_128|
+                      NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY|
+                      //NTLMSSP_NEGOTIATE_ALWAYS_SIGN|
+                      NTLMSSP_NEGOTIATE_NTLM|
+                      //NTLMSSP_NEGOTIATE_SIGN|
+                      NTLMSSP_REQUEST_TARGET|NTLMSSP_NEGOTIATE_OEM|
+                      NTLMSSP_NEGOTIATE_UNICODE);
+        memcpy(&ntlm[12], &u32, 4);
+
+        if (encoder(&ntlm[0], 32, auth_data) < 0) {
+                return -1;
+        }
+
+        return 0;
+}
+
+static int
+ntlm_challenge_message(struct auth_data *auth_data, unsigned char *buf,
+                       int len)
+{
+        free(auth_data->ntlm_buf);
+        auth_data->ntlm_len = len;
+        auth_data->ntlm_buf = (unsigned char*)malloc(auth_data->ntlm_len);
+        if (auth_data->ntlm_buf == NULL) {
+                return -1;
+        }
+        memcpy(auth_data->ntlm_buf, buf, auth_data->ntlm_len);
+
+        return 0;
+}
+
+static int
+NTOWFv2(const char *user, const char *password, const char *domain,
+        unsigned char ntlmv2_hash[16])
+{
+	int i, len, userdomain_len;
+        char *userdomain;
+        char *ucs2_userdomain = NULL;
+        unsigned char ntlm_hash[16];
+
+        ntlm_create_hash(password, ntlm_hash);
+
+        len = strlen(user) + 1;
+        if (domain) {
+                len += strlen(domain);
+        }
+        userdomain = (char*)malloc(len);
+        if (userdomain == NULL) {
+                return -1;
+        }
+
+        strcpy(userdomain, user);
+        for (i = strlen(userdomain) - 1; i >=0; i--) {
+                if (islower(userdomain[i])) {
+                        userdomain[i] = toupper(userdomain[i]);
+                }
+        }
+        if (domain) {
+                strcat(userdomain, domain);
+        }
+
+        ucs2_userdomain = unicode_alloc(userdomain);
+        if (ucs2_userdomain == NULL) {
+                return -1;
+        }
+
+	userdomain_len = strlen(userdomain);
+	HMAC(EVP_md5(), ntlm_hash, 16,
+	     (unsigned char *)ucs2_userdomain, userdomain_len * 2,
+	     ntlmv2_hash, NULL);
+        free(userdomain);
+        free(ucs2_userdomain);
+
+        return 0;
+}
+
+/* This is not the same temp as in MS-NLMP. This temp has an additional
+ * 16 bytes at the start of the buffer.
+ * Use &auth_data->val[16] if you want the temp from MS-NLMP
+ */
+static int
+encode_temp(struct auth_data *auth_data, uint64_t t, char *client_challenge,
+            char *server_challenge, char *server_name, int server_name_len)
+{
+        unsigned char sign[8] = {0x01, 0x01, 0x00, 0x00,
+                                 0x00, 0x00, 0x00, 0x00};
+        unsigned char zero[8] = {0x00, 0x00, 0x00, 0x00,
+                                 0x00, 0x00, 0x00, 0x00};
+
+        if (encoder(&zero, 8, auth_data) < 0) {
+                return -1;
+        }
+        if (encoder(server_challenge, 8, auth_data) < 0) {
+                return -1;
+        }
+        if (encoder(sign, 8, auth_data) < 0) {
+                return -1;
+        }
+        if (encoder(&t, 8, auth_data) < 0) {
+                return -1;
+        }
+        if (encoder(client_challenge, 8, auth_data) < 0) {
+                return -1;
+        }
+        if (encoder(&zero, 4, auth_data) < 0) {
+                return -1;
+        }
+        if (encoder(server_name, server_name_len, auth_data) < 0) {
+                return -1;
+        }
+        if (encoder(&zero, 4, auth_data) < 0) {
+                return -1;
+        }
+
+        return 0;
+}
+
+static int
+encode_ntlm_auth(struct auth_data *auth_data,
+                 char *server_challenge)
+{
+        int ret = -1;
+        unsigned char lm_buf[16];
+        unsigned char *NTChallengeResponse_buf = NULL;
+        unsigned char ResponseKeyNT[16];
+        char *ucs2_domain = NULL;
+	int domain_len;
+        char *ucs2_user = NULL;
+	int user_len;
+        char *ucs2_workstation = NULL;
+	int workstation_len;
+        int NTChallengeResponse_len;
+        unsigned char NTProofStr[16];
+        unsigned char LMStr[16];
+        uint64_t t;
+        struct timeval tv;
+        char *server_name_buf;
+        int server_name_len;
+        uint32_t u32;
+        uint32_t server_neg_flags;
+        unsigned char key_exch[SMB2_KEY_SIZE];
+
+        tv.tv_sec = time(NULL);
+        tv.tv_usec = 0;
+        t = timeval_to_win(&tv);
+
+	/*
+        if (auth_data->password == NULL) {
+                goto finished;
+        }
+	*/
+
+        /*
+         * Generate Concatenation of(NTProofStr, temp)
+         */
+        if (NTOWFv2(auth_data->user, auth_data->password,
+                    auth_data->domain, ResponseKeyNT)
+            < 0) {
+                goto finished;
+        }
+
+        /* get the server neg flags */
+        memcpy(&server_neg_flags, &auth_data->ntlm_buf[20], 4);
+        server_neg_flags = le32toh(server_neg_flags);
+
+        memcpy(&u32, &auth_data->ntlm_buf[40], 4);
+        u32 = le32toh(u32);
+        server_name_len = u32 >> 16;
+
+        memcpy(&u32, &auth_data->ntlm_buf[44], 4);
+        u32 = le32toh(u32);
+        server_name_buf = (char *)&auth_data->ntlm_buf[u32];
+
+        if (encode_temp(auth_data, t, (char *)auth_data->client_challenge,
+                        server_challenge, server_name_buf,
+                        server_name_len) < 0) {
+                return -1;
+        }
+
+	HMAC(EVP_md5(), ResponseKeyNT, 16, &auth_data->buf[8], auth_data->len-8, NTProofStr, NULL);
+        memcpy(auth_data->buf, NTProofStr, 16);
+
+        NTChallengeResponse_buf = auth_data->buf;
+        NTChallengeResponse_len = auth_data->len;
+        auth_data->buf = NULL;
+        auth_data->len = 0;
+        auth_data->allocated = 0;
+
+        /* get the NTLMv2 Key-Exchange Key
+           For NTLMv2 - Key Exchange Key is the Session Base Key
+         */
+	HMAC(EVP_md5(), ResponseKeyNT, 16, NTProofStr, 16, key_exch, NULL);
+        memcpy(auth_data->exported_session_key, key_exch, 16);
+
+        /*
+         * Generate AUTHENTICATE_MESSAGE
+         */
+        encoder("NTLMSSP", 8, auth_data);
+
+        /* message type */
+        u32 = htole32(AUTHENTICATION_MESSAGE);
+        encoder(&u32, 4, auth_data);
+
+        /* lm challenge response fields */
+        memcpy(&lm_buf[0], server_challenge, 8);
+        memcpy(&lm_buf[8], auth_data->client_challenge, 8);
+	HMAC(EVP_md5(), ResponseKeyNT, 16, &lm_buf[0], 16, LMStr, NULL);
+        u32 = htole32(0x00180018);
+        encoder(&u32, 4, auth_data);
+        u32 = 0;
+        encoder(&u32, 4, auth_data);
+
+        /* nt challenge response fields */
+        u32 = htole32((NTChallengeResponse_len<<16)|
+                      NTChallengeResponse_len);
+        encoder(&u32, 4, auth_data);
+        u32 = 0;
+        encoder(&u32, 4, auth_data);
+
+        /* domain name fields */
+        if (auth_data->domain) {
+		domain_len = strlen(auth_data->domain);
+                ucs2_domain = unicode_alloc(auth_data->domain);
+                if (ucs2_domain == NULL) {
+                        goto finished;
+                }
+                u32 = domain_len * 2;
+                u32 = htole32((u32 << 16) | u32);
+                encoder(&u32, 4, auth_data);
+                u32 = 0;
+                encoder(&u32, 4, auth_data);
+        } else {
+                u32 = 0;
+                encoder(&u32, 4, auth_data);
+                encoder(&u32, 4, auth_data);
+        }
+
+        /* user name fields */
+	user_len = strlen(auth_data->user);
+        ucs2_user = unicode_alloc(auth_data->user);
+        if (ucs2_user == NULL) {
+                goto finished;
+        }
+        u32 = user_len * 2;
+        u32 = htole32((u32 << 16) | u32);
+        encoder(&u32, 4, auth_data);
+        u32 = 0;
+        encoder(&u32, 4, auth_data);
+
+        /* workstation name fields */
+        if (auth_data->workstation) {
+		workstation_len = strlen(auth_data->workstation);
+                ucs2_workstation = unicode_alloc(auth_data->workstation);
+                if (ucs2_workstation == NULL) {
+                        goto finished;
+                }
+                u32 = workstation_len * 2;
+                u32 = htole32((u32 << 16) | u32);
+                encoder(&u32, 4, auth_data);
+                u32 = 0;
+                encoder(&u32, 4, auth_data);
+        } else {
+                u32 = 0;
+                encoder(&u32, 4, auth_data);
+                encoder(&u32, 4, auth_data);
+        }
+
+        /* encrypted random session key */
+        u32 = 0;
+        encoder(&u32, 4, auth_data);
+        encoder(&u32, 4, auth_data);
+
+        /* negotiate flags */
+        u32 = htole32(NTLMSSP_NEGOTIATE_56|NTLMSSP_NEGOTIATE_128|
+                      NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY|
+                      //NTLMSSP_NEGOTIATE_ALWAYS_SIGN|
+                      NTLMSSP_NEGOTIATE_NTLM|
+                      //NTLMSSP_NEGOTIATE_SIGN|
+                      NTLMSSP_REQUEST_TARGET|NTLMSSP_NEGOTIATE_OEM|
+                      NTLMSSP_NEGOTIATE_UNICODE);
+        encoder(&u32, 4, auth_data);
+
+        /* append domain */
+        u32 = htole32(auth_data->len);
+        memcpy(&auth_data->buf[32], &u32, 4);
+        if (ucs2_domain) {
+                encoder(ucs2_domain, domain_len * 2, auth_data);
+        }
+
+        /* append user */
+        u32 = htole32(auth_data->len);
+        memcpy(&auth_data->buf[40], &u32, 4);
+        encoder(ucs2_user, user_len * 2, auth_data);
+
+        /* append workstation */
+        u32 = htole32(auth_data->len);
+        memcpy(&auth_data->buf[48], &u32, 4);
+        if (ucs2_workstation) {
+                encoder(ucs2_workstation, workstation_len * 2, auth_data);
+        }
+
+        /* append LMChallengeResponse */
+        u32 = htole32(auth_data->len);
+        memcpy(&auth_data->buf[16], &u32, 4);
+        encoder(LMStr, 16, auth_data);
+        encoder(auth_data->client_challenge, 8, auth_data);
+
+        /* append NTChallengeResponse */
+        u32 = htole32(auth_data->len);
+        memcpy(&auth_data->buf[24], &u32, 4);
+        encoder(NTChallengeResponse_buf, NTChallengeResponse_len, auth_data);
+
+        ret = 0;
+finished:
+        free(ucs2_domain);
+        free(ucs2_user);
+        free(ucs2_workstation);
+        free(NTChallengeResponse_buf);
+
+        return ret;
+}
+
+int
+ntlmssp_generate_blob(struct auth_data *auth_data,
+                      unsigned char *input_buf, int input_len,
+                      unsigned char **output_buf, uint16_t *output_len)
+{
+        free(auth_data->buf);
+        auth_data->buf = NULL;
+        auth_data->len = 0;
+        auth_data->allocated = 0;
+
+        if (input_buf == NULL) {
+                ntlm_negotiate_message(auth_data);
+        } else {
+                if (ntlm_challenge_message(auth_data, input_buf,
+                                           input_len) < 0) {
+                        return -1;
+                }
+                if (encode_ntlm_auth(auth_data,
+                                     (char *)&auth_data->ntlm_buf[24]) < 0) {
+                        return -1;
+                }
+        }
+
+        *output_buf = auth_data->buf;
+        *output_len = auth_data->len;
+
+        return 0;
+}
+
+int
+ntlmssp_get_session_key(struct auth_data *auth,
+                        uint8_t **key,
+                        uint8_t *key_size)
+{
+        uint8_t *mkey = NULL;
+
+        if (auth == NULL || key == NULL || key_size == NULL) {
+                return -1;
+        }
+
+        mkey = (uint8_t *) malloc(SMB2_KEY_SIZE);
+        if (mkey == NULL) {
+                return -1;
+        }
+        memcpy(mkey, auth->exported_session_key, SMB2_KEY_SIZE);
+
+        *key = mkey;
+        *key_size = SMB2_KEY_SIZE;
+
+        return 0;
+}

--- a/ntlmssp.h
+++ b/ntlmssp.h
@@ -1,0 +1,23 @@
+#ifndef NTLMSSP_H
+#define NTLMSSP_H
+
+struct auth_data;
+
+struct auth_data *
+ntlmssp_init_context(const char *user,
+                     const char *password,
+                     const char *domain,
+                     const char *workstation,
+                     const char *client_challenge);
+
+int
+ntlmssp_generate_blob(struct auth_data *auth_data,
+                      unsigned char *input_buf, int input_len,
+                      unsigned char **output_buf, uint16_t *output_len);
+
+void
+ntlmssp_destroy_context(struct auth_data *auth);
+
+int ntlmssp_get_session_key(struct auth_data *auth, uint8_t **key, uint8_t *key_size);
+
+#endif

--- a/opensshlib/config.h.in
+++ b/opensshlib/config.h.in
@@ -1,5 +1,8 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
+
 /* Define if you have a getaddrinfo that fails for the all-zeros IPv6 address
    */
 #undef AIX_GETNAMEINFO_HACK
@@ -1100,28 +1103,28 @@
 /* define if you have struct in6_addr data type */
 #undef HAVE_STRUCT_IN6_ADDR
 
-/* Define to 1 if `pw_change' is member of `struct passwd'. */
+/* Define to 1 if `pw_change' is a member of `struct passwd'. */
 #undef HAVE_STRUCT_PASSWD_PW_CHANGE
 
-/* Define to 1 if `pw_class' is member of `struct passwd'. */
+/* Define to 1 if `pw_class' is a member of `struct passwd'. */
 #undef HAVE_STRUCT_PASSWD_PW_CLASS
 
-/* Define to 1 if `pw_expire' is member of `struct passwd'. */
+/* Define to 1 if `pw_expire' is a member of `struct passwd'. */
 #undef HAVE_STRUCT_PASSWD_PW_EXPIRE
 
-/* Define to 1 if `pw_gecos' is member of `struct passwd'. */
+/* Define to 1 if `pw_gecos' is a member of `struct passwd'. */
 #undef HAVE_STRUCT_PASSWD_PW_GECOS
 
 /* define if you have struct sockaddr_in6 data type */
 #undef HAVE_STRUCT_SOCKADDR_IN6
 
-/* Define to 1 if `sin6_scope_id' is member of `struct sockaddr_in6'. */
+/* Define to 1 if `sin6_scope_id' is a member of `struct sockaddr_in6'. */
 #undef HAVE_STRUCT_SOCKADDR_IN6_SIN6_SCOPE_ID
 
 /* define if you have struct sockaddr_storage data type */
 #undef HAVE_STRUCT_SOCKADDR_STORAGE
 
-/* Define to 1 if `st_blksize' is member of `struct stat'. */
+/* Define to 1 if `st_blksize' is a member of `struct stat'. */
 #undef HAVE_STRUCT_STAT_ST_BLKSIZE
 
 /* Define to 1 if the system has the type `struct timespec'. */
@@ -1486,6 +1489,9 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
@@ -1672,12 +1678,25 @@
 /* include SSH protocol version 1 support */
 #undef WITH_SSH1
 
-/* Define to 1 if your processor stores words with the most significant byte
-   first (like Motorola and SPARC, unlike Intel and VAX). */
-#undef WORDS_BIGENDIAN
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif
 
 /* Define if xauth is found in your path */
 #undef XAUTH_PATH
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 #undef _FILE_OFFSET_BITS

--- a/opensshlib/configure
+++ b/opensshlib/configure
@@ -709,7 +709,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -834,7 +833,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1087,15 +1085,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1233,7 +1222,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1386,7 +1375,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -5324,7 +5312,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -5370,7 +5358,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -5394,7 +5382,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -5439,7 +5427,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -5463,7 +5451,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];


### PR DESCRIPTION
MS is now violently deprecating and disabling SMB1.

Doing multi-dialect in SMB1 module (try SMB1 then when it fails SMB2) would just make more round trips  