### PR TITLE
Fix SSH crash (Probably #38)

### DIFF
--- a/modules/ncrack_mysql.cc
+++ b/modules/ncrack_mysql.cc
@@ -251,6 +251,7 @@ mysql_loop_read(nsock_pool nsp, Connection *con, char *mysql_auth_method, char *
             p++;
           }
         }
+        server_authentication_method[i] = '\0';
         server_authentication_method[strlen(server_authentication_method) + 1] = '\0';
         //printf("Server default authentication: %s\n", server_authentication_method);
         strncpy(mysql_auth_method, server_authentication_method, strlen(server_authentication_method));

--- a/opensshlib/dh.c
+++ b/opensshlib/dh.c
@@ -262,7 +262,7 @@ dh_pub_is_valid(DH *dh, const BIGNUM *dh_pub)
 int
 dh_gen_key(DH *dh, int need)
 {
-	int pbits;
+	int r, pbits;
 	const BIGNUM *dh_p, *dh_pub_key;
 	DH_get0_pqg(dh, &dh_p, NULL, NULL);
 
@@ -271,8 +271,9 @@ dh_gen_key(DH *dh, int need)
 	    need > INT_MAX / 2 || 2 * need > pbits)
 		return SSH_ERR_INVALID_ARGUMENT;
 	DH_set_length(dh, MIN(need * 2, pbits - 1));
+	r = DH_generate_key(dh);
 	DH_get0_key(dh, &dh_pub_key, NULL);
-	if (DH_generate_key(dh) == 0 ||
+	if (r == 0 ||
 	    !dh_pub_is_valid(dh, dh_pub_key)) {
 		return SSH_ERR_LIBCRYPTO_ERROR;
 	}

--- a/opensshlib/kexgexc.c
+++ b/opensshlib/kexgexc.c
@@ -125,10 +125,11 @@ ncrackssh_input_kex_dh_gex_group(ncrack_ssh_state *nstate)
 		goto out;
 	}
 	p = g = NULL; /* belong to kex->dh now */
+	r = dh_gen_key(kex->dh, kex->we_need * 8);
 	DH_get0_key(kex->dh, &kex_dh_pub_key, NULL);
 
 	/* generate and send 'e', client DH public key */
-	if ((r = dh_gen_key(kex->dh, kex->we_need * 8)) != 0 ||
+	if (r != 0 ||
 	    (r = sshpkt_start(nstate, SSH2_MSG_KEX_DH_GEX_INIT)) != 0 ||
 	    (r = sshpkt_put_bignum2(nstate, kex_dh_pub_key)) != 0 ||
 	    (r = sshpkt_send(nstate)) != 0)


### PR DESCRIPTION
ncrack will crash if the server is configured to KexAlgorithms diffie-hellman-group-exchange-sha256 or diffie-hellman-group-exchange-sha1.

Signed-off-by: Christian Inci <chris.gh@broke-the-inter.net>