### PR TITLE
Band-aid for MySQL (Probably a part of #9)

### DIFF
--- a/modules/ncrack_mysql.cc
+++ b/modules/ncrack_mysql.cc
@@ -279,6 +279,7 @@ mysql_loop_read(nsock_pool nsp, Connection *con, char *mysql_auth_method, char *
       for (i = 0; i < 21 ; i++){
         server_authentication_method[i] = *p++;
       }
+      server_authentication_method[i] = '\0';
       server_authentication_method[strlen(server_authentication_method) + 1] = '\0';
       strncpy(mysql_auth_method, server_authentication_method, strlen(server_authentication_method));
 

--- a/modules/ncrack_mysql.cc
+++ b/modules/ncrack_mysql.cc
@@ -251,6 +251,7 @@ mysql_loop_read(nsock_pool nsp, Connection *con, char *mysql_auth_method, char *
             p++;
           }
         }
+        server_authentication_method[i] = '\0';
         server_authentication_method[strlen(server_authentication_method) + 1] = '\0';
         //printf("Server default authentication: %s\n", server_authentication_method);
         strncpy(mysql_auth_method, server_authentication_method, strlen(server_authentication_method));


### PR DESCRIPTION
The printf returns "mysql_native_password" with three 0xff-bytes at the end.

You might want to put that band-aid at the "packet_number == 2"-condition too, but having it at the "packet_number == 0"-condition seems to be enough to avoid a crash.

Tested on Ubuntu 19.04 with a local MySQL server:
ncrack --user root --pass root mysql://127.0.0.0/31

Signed-off-by: Christian Inci <chris.gh@broke-the-inter.net>