### PR TITLE
NetBSD does not need any macro (re)adjustments

### DIFF
--- a/portable_endian.h
+++ b/portable_endian.h
@@ -81,11 +81,11 @@
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
 
-#elif defined(__OpenBSD__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__)
 
 #	include <sys/endian.h>
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 
 #	include <sys/endian.h>
 


### PR DESCRIPTION
NetBSD [byteorder(9)](https://netbsd.gw.com/cgi-bin/man-cgi?byteorder+9+NetBSD-current) already provides all macros needed.

This fixes the build on NetBSD.