### PR TITLE
Remove unused global variable / Fixes gcc-10 "multiple definition of" error.

### DIFF
--- a/opensshlib/umac.c
+++ b/opensshlib/umac.c
@@ -1181,7 +1181,7 @@ struct umac_ctx {
     uhash_ctx hash;          /* Hash function for message compression    */
     pdf_ctx pdf;             /* PDF for hashed output                    */
     void *free_ptr;          /* Address to free this struct via          */
-} umac_ctx;
+};
 
 /* ---------------------------------------------------------------------- */
 


### PR DESCRIPTION
Fixes gcc-10 "multiple definition of" error.

I tried to build master for Arch Linux:

```
/usr/bin/ld: opensshlib/libopenssh.a(umac128.o):/home/juergen/Github Mirrors/nmap/ncrack/opensshlib/./umac.c:1184: multiple definition of `umac_ctx'; opensshlib/libopenssh.a(umac.o):/home/juergen/Github Mirrors/nmap/ncrack/opensshlib/umac.c:1184: first defined here
collect2: Fehler: ld gab 1 als Ende-Status zurück

```