### PR TITLE
Add aliases for psql and mongodb for nmap xml input compatibility

### DIFF
--- a/ncrack-services
+++ b/ncrack-services
@@ -34,6 +34,7 @@ mysql 3306/tcp
 ms-wbt-server 3389/tcp
 rdp 3389/tcp
 psql 5432/tcp
+postgresql 5432/tcp
 vnc 5801/tcp
 vnc 5900/tcp
 vnc 5901/tcp
@@ -45,4 +46,5 @@ couchbase 8091/tcp
 cassandra 9160/tcp
 cassandra 9042/tcp
 mongodb 27017/tcp
+mongod 27017/tcp
 cvs 2401/tcp

--- a/ncrack.cc
+++ b/ncrack.cc
@@ -804,13 +804,13 @@ call_module(nsock_pool nsp, Connection *con)
     ncrack_webform(nsp, con);
   else if (!strcmp(name, "winrm"))
     ncrack_winrm(nsp, con);
-  else if (!strcmp(name, "mongodb"))
+  else if (!strcmp(name, "mongodb") || !strcmp(name, "mongod"))
     ncrack_mongodb(nsp, con);
   else if (!strcmp(name, "pop3s"))
     ncrack_pop3(nsp, con);
   else if (!strcmp(name, "mysql"))
     ncrack_mysql(nsp, con);
-  else if (!strcmp(name, "psql"))
+  else if (!strcmp(name, "psql") || !strcmp(name, "postgresql"))
     ncrack_psql(nsp, con);  
   else if (!strcmp(name, "mssql"))
     ncrack_mssql(nsp, con);


### PR DESCRIPTION
This PR solves problem with Nmap XML input compatibility for services postgresql(psql) and mongod(mongodb) by adding aliases. issue #109 