### PR TITLE
Allow zlib versions with two-part version number

### DIFF
--- a/opensshlib/configure
+++ b/opensshlib/configure
@@ -8922,7 +8922,7 @@ main ()
 
 	int a=0, b=0, c=0, d=0, n, v;
 	n = sscanf(ZLIB_VERSION, "%d.%d.%d.%d", &a, &b, &c, &d);
-	if (n != 3 && n != 4)
+	if (n != 2 && n != 3 && n != 4)
 		exit(1);
 	v = a*1000000 + b*10000 + c*100 + d;
 	fprintf(stderr, "found zlib version %s (%d)\n", ZLIB_VERSION, v);

--- a/opensshlib/configure.ac
+++ b/opensshlib/configure.ac
@@ -1234,7 +1234,7 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 	[[
 	int a=0, b=0, c=0, d=0, n, v;
 	n = sscanf(ZLIB_VERSION, "%d.%d.%d.%d", &a, &b, &c, &d);
-	if (n != 3 && n != 4)
+	if (n != 2 && n != 3 && n != 4)
 		exit(1);
 	v = a*1000000 + b*10000 + c*100 + d;
 	fprintf(stderr, "found zlib version %s (%d)\n", ZLIB_VERSION, v);


### PR DESCRIPTION
This makes ncrack build with zlib version 1.3.