### PR TITLE
define _GNU_SOURCE to resolve implicit declaration of vasprintf

### DIFF
--- a/opensshlib/xmalloc.c
+++ b/opensshlib/xmalloc.c
@@ -13,6 +13,7 @@
  * called by a name other than "ssh" or "Secure Shell".
  */
 
+#define _GNU_SOURCE
 #include "includes.h"
 
 #include <stdarg.h>


### PR DESCRIPTION
This MR resolves the following implicit declaration warning (https://github.com/nmap/ncrack/issues/137):
```
xmalloc.c: In function ‘xasprintf’:
xmalloc.c:114:13: error: implicit declaration of function ‘vasprintf’; did you mean ‘xasprintf’? [-Werror=implicit-function-declaration]
  114 |         i = vasprintf(ret, fmt, ap);
      |             ^~~~~~~~~
      |             xasprintf
```

Debian unstable build succeeds after applying https://github.com/nmap/ncrack/pull/135 and this PR.
